### PR TITLE
ベーシック認証の実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,17 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth, if: :production?
+  protect_from_forgery with: :exception
+
+  private
+
+  def production?
+    Rails.env.production?
+  end
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,5 +13,4 @@ class ApplicationController < ActionController::Base
       username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
     end
   end
-
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -32,3 +32,10 @@ namespace :deploy do
     invoke 'unicorn:restart'
   end
 end
+
+set :default_env, {
+  rbenv_root: "/usr/local/rbenv",
+  path: "/usr/local/rbenv/shims:/usr/local/rbenv/bin:$PATH",
+  BASIC_AUTH_USER: ENV["BASIC_AUTH_USER"],
+  BASIC_AUTH_PASSWORD: ENV["BASIC_AUTH_PASSWORD"]
+}

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -7,7 +7,9 @@
 # server "example.com", user: "deploy", roles: %w{app web}, other_property: :other_value
 # server "db.example.com", user: "deploy", roles: %w{db}
 
-
+server '13.112.188.213', user: 'ec2-user', roles: %w{app db web}
+set :rails_env, "production"
+set :unicorn_rack_env, "production"
 
 # role-based syntax
 # ==================
@@ -61,4 +63,3 @@
 #   }
 
 	
-server '13.112.188.213', user: 'ec2-user', roles: %w{app db web}


### PR DESCRIPTION
#What
ベーシック認証をするための設定を追加しました。

#Why 
メルカリのコピーサイトを関係者以外に見せないようにして、事故を減らすため。