### PR TITLE
ログアウト画面の部分テンプレート化

### DIFF
--- a/app/assets/stylesheets/logout.scss
+++ b/app/assets/stylesheets/logout.scss
@@ -1,0 +1,20 @@
+@import "variable.scss";
+.log-out-box{
+  background-color: $white;
+  height: 179px;
+  width:700px;
+  padding: 64px;
+  box-sizing: border-box;
+  &__button{
+  display: block;
+  width:500px;
+  height: 51px;
+  background-color: $red;
+  color: $white;
+  font-size: 14px;
+  text-align: center;
+  line-height: 3.5;
+  margin: auto;
+  text-decoration: none;
+ }
+}

--- a/app/views/shared/_logout.haml
+++ b/app/views/shared/_logout.haml
@@ -1,0 +1,2 @@
+.log-out-box
+  =link_to "ログアウト", "",class: "log-out-box__button"


### PR DESCRIPTION
# What
作業内容
ログアウト時にサイドバー横に表示されるビュー
および、それに付随するscss
ビューは部分テンプレート化してshared以下に配置

# Why
押しやすいログアウトボタンを実装するため

背景が白でみにくいため、検証ツールを用いた確認用画像を以下に添付します。

<img width="708" alt="スクリーンショット 2019-07-23 14 15 19" src="https://user-images.githubusercontent.com/51849294/61684630-0937fb80-ad55-11e9-8b31-d9282ea5d6b8.png">

