### PR TITLE
add profiele form view

### DIFF
--- a/app/assets/stylesheets/mixin.scss
+++ b/app/assets/stylesheets/mixin.scss
@@ -45,3 +45,11 @@
   background-size: 12px 10px;
   background-position: right 10px center;
 }
+@mixin submit-button($fSize,$fColor){
+  font-size: 14px;
+  height:50px;
+  width:$fSize;
+  color:$white;
+  background-color:$fColor;
+  text-align: center;
+}

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -1,0 +1,68 @@
+@import"variable.scss";
+@import"mixin.scss";
+
+.profile-edit{
+  @include box(565px);
+  &__title{
+    @include title-box;
+  }
+  &__top-box{
+    box-sizing: border-box;
+    height: 156px;
+    width:700px;
+    padding: 72px 16px 24px;
+    background-image:url("mypage-background.jpg");
+    margin: auto;
+    &__container{
+      margin: auto;
+      display: flex;
+      width:263px;
+    }
+    &__name{
+      display: block;
+      width:208px;
+      height: 48px;
+      border-radius: 5px;
+      font-size: 14px;
+      border-style: solid;
+      border-color:$pale_gray;
+      box-sizing: border-box;
+      margin-top: 10px;
+      padding: 10px 16px 8px;
+    }
+    &__avator{
+      height: 60px;
+      width: 60px;
+      margin-right: 5px;
+      border-radius: 40px;
+    }
+  }
+  &__under-box{
+    height: 362px;
+    width: 700px;
+    padding: 40px 16px;
+    box-sizing: border-box;
+    &__input{
+      height: 216px;
+      width: 668px;
+      padding: 10px;
+      box-sizing: border-box;
+      margin-top:5px;
+      &__form{
+        font-size: 14px;
+        padding: 10px;
+        box-sizing: border-box;
+        height: 100%;
+        width: 100%;
+      }
+    }
+   &__submit{
+    display: block;
+    text-decoration: none;
+    @include submit-button(100%,$red);
+    box-sizing: border-box;
+    margin-top: 15px;
+    line-height: 50px;
+   }
+  }
+}

--- a/app/views/shared/_profile_form.haml
+++ b/app/views/shared/_profile_form.haml
@@ -1,0 +1,11 @@
+.profile-edit
+  .profile-edit__title
+    プロフィール
+  .profile-edit__top-box
+    .profile-edit__top-box__container
+      = image_tag "/assets/avator.png", class:"profile-edit__top-box__avator"
+      %input.profile-edit__top-box__name{placeholder: "current_user.name"}
+  .profile-edit__under-box
+    .profile-edit__under-box__input
+      =  text_area :profile, :profile, class: "profile-edit__under-box__input__form",placeholder: "current_user.profile（空であれば定型文を記述してください）" 
+    = link_to "変更する", "" ,{class: "profile-edit__under-box__submit"}


### PR DESCRIPTION
## What
プロフィール編集フォームを作成しました。

【作業内容】
部分テンプレート化した仮置きのプロフィール編集ページをshared以下に配置
scssの作成
重複しそうなボタン部分のmixinの作成

## Why
プロフィールの編集を容易にするため

今回の変更により追加されるビュー画面は以下の通りです。
<img width="717" alt="プロフィール編集画面" src="https://user-images.githubusercontent.com/51849294/61843493-d74ea280-aed6-11e9-9297-bc9afdfd0631.png">