### PR TITLE
多階層カテゴリの紐付けのためのアソシエーション、DBの変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,28 +71,16 @@ Things you may want to cover:
 |user_id|integer|null: false, foreign_key: true|
 |status|integer|default: 0|
 |brand_id|integer|foreign_key: true|
+|category_id|integer|foreign_key: true|
 
 
 ## association
 - has_many :images
 - has_many :likes
 - has_many :comments
-- has_many :categories, through: :item_categories
-- has_many :item_categories
+- belongs_to :categories
 - belongs_to :user
 - belongs_to :brand
-
-
-## item_categories table
-|Colmun|Type|Options|
-|------|----|-------|
-|item_id|integer|null: false, foreign_key: true|
-|category_id|integer|null: false, foreign_key: true|
-
-## association
-- belongs_to :item
-- belongs_to :category
-
 
 ## categories table
 |Colmun|Type|Options|
@@ -100,8 +88,7 @@ Things you may want to cover:
 |name|string|null: false, index: true|
 
 ## association
-- has_many :item_categories
-- has_many :items, through: :item_categories
+- has_many :items
 - has_ancestry
 
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Things you may want to cover:
 - has_many :images
 - has_many :likes
 - has_many :comments
-- belongs_to :categories
+- belongs_to :category
 - belongs_to :user
 - belongs_to :brand
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,5 +1,6 @@
 class Category < ApplicationRecord
-  has_many :items,through: :item_categories
-  has_many :item_categories
+  has_many :items
+  #through: :item_categories
+  #has_many :item_categories
   has_ancestry
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,6 +1,4 @@
 class Category < ApplicationRecord
   has_many :items
-  #through: :item_categories
-  #has_many :item_categories
   has_ancestry
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,5 @@
 class Item < ApplicationRecord
   belongs_to :user
+  belongs_to :category
   has_many :images
 end

--- a/db/migrate/20190728225215_create_items.rb
+++ b/db/migrate/20190728225215_create_items.rb
@@ -14,6 +14,7 @@ class CreateItems < ActiveRecord::Migration[5.2]
       t.integer :user_id, null:false , foreign_key: true
       t.integer :status, default: 0
       t.integer :brand_id, foreign_key: true
+      t.integer :category_id, foreign_key: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_29_063210) do
+ActiveRecord::Schema.define(version: 2019_07_29_062935) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
+    t.string "categories"
+    t.string "ancestry"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "ancestry"
     t.index ["ancestry"], name: "index_categories_on_ancestry"
+    t.index ["categories"], name: "index_categories_on_categories"
     t.index ["name"], name: "index_categories_on_name"
   end
 
@@ -42,6 +44,7 @@ ActiveRecord::Schema.define(version: 2019_07_29_063210) do
     t.integer "user_id", null: false
     t.integer "status", default: 0
     t.integer "brand_id"
+    t.integer "category_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
## What 
ItemsとCategoriesのアソシエーションの変更と、不要な中間テーブルを廃止しました。
Itemを孫カテゴリーに属させることで、子、親カテゴリーを引っ張って来られるようにするという変更です。

それに伴いREADMEも変更しました。

## Why
当初の多対多のカテゴリー関係よりシンプルにカテゴリーが扱えるようになります。
以下がダミーデータから子、親カテゴリーを持ってくる場合のコンソールの画像です。

<img width="992" alt="スクリーンショット 2019-07-31 13 00 45" src="https://user-images.githubusercontent.com/51849294/62182936-58081580-b393-11e9-9a16-7a7ce63d949c.png">
