### PR TITLE
カテゴリ検索ウインドウの実装

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,6 @@
 //= require jquery 
 //= require rails-ujs
 //= require activestorage
-//= require turbolinks
+
 //= require_tree .
 

--- a/app/assets/javascripts/search_window.js
+++ b/app/assets/javascripts/search_window.js
@@ -1,0 +1,70 @@
+$(function() {
+  function buildChildHTML(child){
+    var html =`<a class="child_category" id="${child.id}" 
+                href="/category/${child.id}">${child.name}</a>`;
+    return html;
+  }
+
+  // 子カテゴリーを追加するための処理です。
+  $(".parent_category").on("mouseover", function() {
+    var id = this.id
+    $(".now-selected-red").removeClass("now-selected-red")
+    $('#' + id).addClass("now-selected-red");
+    $(".child_category").remove();
+    $(".grand_child_category").remove();
+    $.ajax({
+      type: 'GET',
+      url: '/category/new',
+      data: {parent_id: id},
+      dataType: 'json'
+    }).done(function(children) {
+      children.forEach(function (child) {
+        var html = buildChildHTML(child);
+        $(".children_list").append(html);
+      })
+    });
+  });
+
+  // 孫カテゴリを追加する処理です
+  function buildGrandChildHTML(child){
+    var html =`<a class="grand_child_category" id="${child.id}"
+               href="/category/${child.id}">${child.name}</a>`;
+    return html;
+  }
+
+  $(document).on("mouseover", ".child_category", function () {
+    var id = this.id
+    $(".now-selected-gray").removeClass("now-selected-gray")
+    $('#' + id).addClass("now-selected-gray");
+ 
+    $.ajax({
+      type: 'GET',
+      url: '/category/new',
+      data: {parent_id: id},
+      dataType: 'json'
+    }).done(function(children) {
+      children.forEach(function (child) {
+        var html = buildGrandChildHTML(child);
+        console.log(html);
+        $(".grand_children_list").append(html);
+      })
+      $(document).on("mouseover", ".child_category", function () {
+        $(".grand_child_category").remove();
+      });
+    });
+  });
+
+  // リストを表示させる処理
+  $(".append-categories").on("mouseover", function(){
+    $(".parents_list").removeClass("hidden-categories");
+  });
+
+  // リストを削除する処理
+  $(".item-categories").on("mouseleave",function(){
+    $(".parents_list").addClass("hidden-categories");
+    $(".child_category").remove();
+    $(".grand_child_category").remove();
+    $(".now-selected-red").removeClass("now-selected-red")
+    $(".now-selected-gray").removeClass("now-selected-gray")
+  });
+});

--- a/app/assets/javascripts/search_window.js
+++ b/app/assets/javascripts/search_window.js
@@ -45,7 +45,6 @@ $(function() {
     }).done(function(children) {
       children.forEach(function (child) {
         var html = buildGrandChildHTML(child);
-        console.log(html);
         $(".grand_children_list").append(html);
       })
       $(document).on("mouseover", ".child_category", function () {

--- a/app/assets/stylesheets/_category-list.scss
+++ b/app/assets/stylesheets/_category-list.scss
@@ -1,0 +1,45 @@
+.category_list{
+  position: absolute;
+  display: flex;
+  left:250px;
+  z-index: 100;
+}
+
+.parent_category{
+  @include category-list;
+}
+
+.child_category{
+  @include category-list;
+}
+
+.grand_child_category{
+  @include category-list;
+  &:hover{
+    color: $white;
+    background-color: $button-gray;
+  }
+}
+
+.item-categories{
+  background-color:$white ;
+  border-right: 1px solid $black;
+  border-left: 1px solid $black;
+  border-bottom: 1px solid $black;
+}
+
+.hidden-categories{
+  display:none;
+}
+
+.now-selected-red{
+  font-weight: bold;
+  color: $white;
+  background-color: $red;
+}
+
+.now-selected-gray{
+  font-weight: bold;
+  color: $white;
+  background-color: $button-gray;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -44,3 +44,4 @@
  @import './new-login.scss';
  @import './footer-log.scss';
  @import './search.scss';
+ @import './category-list.scss';

--- a/app/assets/stylesheets/mixin.scss
+++ b/app/assets/stylesheets/mixin.scss
@@ -54,3 +54,16 @@
   background-color:$fColor;
   text-align: center;
 }
+@mixin category-list{
+  font-size: 12px;
+  display: block;
+  text-decoration: none;
+  color: $black;
+  background-color: $white;
+  line-height: 20px;
+  height:50px;
+  width:220px;
+  padding: 13px;
+  box-sizing: border-box;
+  z-index: 3;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :basic_auth, if: :production?
   protect_from_forgery with: :exception
+  before_action :set_parents
 
   private
 
@@ -12,5 +13,9 @@ class ApplicationController < ActionController::Base
     authenticate_or_request_with_http_basic do |username, password|
       username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
     end
+  end
+
+  def set_parents
+    @parents = Category.where(ancestry: nil)
   end
 end

--- a/app/controllers/category_controller.rb
+++ b/app/controllers/category_controller.rb
@@ -1,0 +1,12 @@
+class CategoryController < ApplicationController  
+  def new
+    @children = Category.find(params[:parent_id]).children
+    respond_to do |format|
+      format.html
+      format.json
+    end
+  end
+
+  def show
+  end
+end

--- a/app/views/category/new.json.jbuilder
+++ b/app/views/category/new.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @children do |child|
+  json.id child.id
+  json.name child.name
+end

--- a/app/views/shared/_header.haml
+++ b/app/views/shared/_header.haml
@@ -58,6 +58,6 @@
 .category_list.item-categories
   .parents_list.hidden-categories
     - @parents.each do |parent|
-      = link_to "#{parent.name}", "category/#{parent.id}",class: "parent_category",id: "#{parent.id}"
+      = link_to "#{parent.name}", category_path(parent), class: "parent_category",id: "#{parent.id}"
   .children_list
   .grand_children_list

--- a/app/views/shared/_header.haml
+++ b/app/views/shared/_header.haml
@@ -15,13 +15,13 @@
     .toppage-header__box__bottom
       .toppage-header__box__bottom__li
         %ul.toppage-header__box__bottom__li__left
-          %li.toppage-header__box__bottom__li__left__li-search
-            = fa_icon 'list-ul', class: "search-icon-left"
-            = link_to "", class: "search-brand-category" do
+          %li.toppage-header__box__bottom__li__left__li-search.append-categories
+            = fa_icon 'list-ul', class: "search-icon-left append-categories"
+            = link_to "", class: "search-brand-category append-categories" do
               カテゴリーから探す
           %li.toppage-header__box__bottom__li__left__li-search
             = fa_icon 'tag', class: "search-icon-left"
-            = link_to "", class: "search-brand-category" do
+            = link_to "", class: "search-brand-category append-ctegories" do
               ブランドから探す
 
         -# #ログインしている場合
@@ -52,3 +52,12 @@
         -#   %li.toppage-header__box__bottom__li__right2__login
         -#     = link_to "", class: "toppage-header__box__bottom__li__right2__login__icon" do
         -#       ログイン
+
+
+-# カテゴリ検索のためのビュー(8/5追加)
+.category_list.item-categories
+  .parents_list.hidden-categories
+    - @parents.each do |parent|
+      = link_to "#{parent.name}", "category/#{parent.id}",class: "parent_category",id: "#{parent.id}"
+  .children_list
+  .grand_children_list

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root 'test#index'
   resources :search,only: [:index]
-  resources :category 
+  resources :category,only:[:show,:new]
   resource :mypage do
     resource :profile ,only: [:show]
     resource :card ,only: [:show,:create] 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   root 'test#index'
   resources :search,only: [:index]
+  resources :category 
   resource :mypage do
     resource :profile ,only: [:show]
     resource :card ,only: [:show,:create] 


### PR DESCRIPTION
## What
ヘッダー部分のカテゴリ検索のビューの作成

作業内容
多階層カテゴリのそれぞれのパスをもつリンクを非同期で追加し、
仮置きのビューに渡すようにしました。

## Why
直感的に多階層カテゴリの検索ができるようにするため。
本家メルカリと異なり、それぞれの幅を揃えて、操作しやすくしています。

動作確認は以下でお願いします。
https://gyazo.com/8c32ba73d4b5a1ff53171c497dd6ffea