### PR TITLE
多階層カテゴリのビュー、パンくずリストの実装

### DIFF
--- a/app/assets/stylesheets/_category_show.scss
+++ b/app/assets/stylesheets/_category_show.scss
@@ -1,0 +1,38 @@
+.category-show{
+  background-color:$background_gray;
+  &__title{
+    font-weight: bold;
+    font-size:20px;
+    color:$black;
+    width:1020px;
+    margin: auto;
+  }
+  &__results{
+    width: 1020px;
+    margin: auto;
+  }
+}
+
+.category-breads{    
+  width: 990px;
+  margin: auto;
+  line-height: 25px;
+  &__links{
+    text-decoration: none;
+    color: $black;
+    &:hover{
+      text-decoration: underline;
+    }
+  }
+  &__icon{
+    margin:0 ５px;
+  }
+  &__selected{
+    display: inline;
+    font-weight: bold;
+  }
+}
+
+.bread-box{
+  border-top:solid,1px,$black;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -45,4 +45,5 @@
  @import './footer-log.scss';
  @import './search.scss';
  @import './category-list.scss';
- @import './category_index.scss'
+ @import './category_index.scss';
+ @import './category_show.scss';

--- a/app/controllers/category_controller.rb
+++ b/app/controllers/category_controller.rb
@@ -8,5 +8,6 @@ class CategoryController < ApplicationController
   end
 
   def show
+    @category = Category.find(params[:id])
   end
 end

--- a/app/views/category/show.haml
+++ b/app/views/category/show.haml
@@ -1,0 +1,25 @@
+= render "shared/header"
+.second-header
+.second-header__box.bread-box
+  .category-breads
+    = link_to "メルカリ",root_path, class:"category-breads__links"
+    = fa_icon 'angle-right' ,class:"category-breads__icon"
+    = link_to "カテゴリ一覧",category_index_path ,class:"category-breads__links"
+    = fa_icon 'angle-right' ,class:"category-breads__icon"
+    - if @category.ancestors?
+      - @category.ancestors.ids.each do |id|
+        = link_to "#{Category.find(id).name}" ,category_path(id) ,class:"category-breads__links"
+        = fa_icon 'angle-right' ,class:"category-breads__icon"
+    .category-breads__selected
+      = @category.name 
+.category-show
+  .category-show__title
+    = @category.name + "の商品一覧"
+  .category-show__results
+    
+-# ここに検索結果の一覧を表示
+
+.toppage-footer__image
+  = image_tag 'mercari__footer.jpg', class: 'footer__image__pic', height: '260', width: '100%'
+= render "shared/footer"
+= render "shared/red-camera"


### PR DESCRIPTION
## What
categoryのshowアクションのビューと、そのためのパンくずリストを実装しました。

## Why
ユーザがカテゴリ検索を快適に行うことができます。

確認用の画像は以下です。

<img width="890" alt="スクリーンショット 2019-08-08 21 09 41" src="https://user-images.githubusercontent.com/51849294/62702407-a6678500-ba21-11e9-9b75-2905d9f0937d.png">
