### PR TITLE
検索結果のビューを表示する

### DIFF
--- a/app/assets/stylesheets/_item-search_template.scss
+++ b/app/assets/stylesheets/_item-search_template.scss
@@ -1,0 +1,61 @@
+.item-search-results{
+  width: 750px;
+  height: auto;
+}
+
+.itemsearch-box{
+  display: inline-block;
+  height: 220px;
+  width:160px;
+  margin:10px;
+  background-color: $white;
+  box-sizing: border-box;
+  position: relative;
+  &__picture{
+    height: 160px;
+    width:160px;
+  }
+  &__link{
+    text-decoration: none;
+    color:$black;
+    height:0px;
+    box-sizing: border-box;
+  }
+  &__discription{
+    height: 60px;
+    width:160px;
+    padding: 8px 12px;
+    box-sizing: border-box;
+    background-color: $white;
+    &__info{
+      display: flex;
+      text-decoration: none;
+    }
+    &__price{
+      text-decoration: none;
+    }
+    &__like{
+      margin-left: 10px;
+      text-decoration: none;
+    }
+  }
+}
+
+.sold-flag{
+  position: absolute;
+  top:0px ;
+  border-top: 50px solid $red;
+  border-right: 50px solid transparent;
+  border-bottom: 50px solid transparent;
+  border-left: 50px solid $red;
+  &__text{
+    font-family: Arial, Helvetica, sans-serif;
+    color: $white;
+    top: 20px;
+    left:5px;
+    font-size: 25px;
+    font-weight: bold;
+    position: absolute;
+    -webkit-transform: rotate(-45deg);
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -47,3 +47,4 @@
  @import './category-list.scss';
  @import './category_index.scss';
  @import './category_show.scss';
+ @import './item-search_template.scss';

--- a/app/controllers/category_controller.rb
+++ b/app/controllers/category_controller.rb
@@ -9,5 +9,7 @@ class CategoryController < ApplicationController
 
   def show
     @category = Category.find(params[:id])
+    # @itemsはより精度の高い検索結果を実装した後に配列で返す予定です。（8.10 祖父江）
+    @items = Item.where(category_id: params[:id])
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,5 +1,6 @@
 class SearchController < ApplicationController
   def index
+    @keywords = params[:search]
     keywords = params[:search]&.split(/[[:blank:]]+/)
     @items = []
     keywords&.each do |keyword| 

--- a/app/views/category/show.haml
+++ b/app/views/category/show.haml
@@ -16,8 +16,8 @@
   .category-show__title
     = @category.name + "の商品一覧"
   .category-show__results
-    
--# ここに検索結果の一覧を表示
+    - @items.each do |item|
+      = render 'shared/search-item' , item: item
 
 .toppage-footer__image
   = image_tag 'mercari__footer.jpg', class: 'footer__image__pic', height: '260', width: '100%'

--- a/app/views/search/index.haml
+++ b/app/views/search/index.haml
@@ -198,28 +198,16 @@
               %label.checkbox-box__condition
                 売り切れ
         .search-button
-          
           .search-button-reset
             クリア
           .search-button-submit
             完了
-
     .right-side
       %h3.right-side__title
         新着商品
-      .itembox-content
-        %section.itembox-content__image-box
-          %figure.imagebox-content__image-box__photo
-            = image_tag "mercarinasi.jpg",height:'160px',width:'160px'
-          .photo-box
-            %h3.photo-box__name
-              はらドーナツ
-            .item-box-price
-              .item-box-price__num
-                ¥ 100
-              .item-box-price__like
-                = fa_icon 'heart-o', class:'heart'
-                %span.item-box-price__like__num 4
+      .item-search-results
+        - @items.each do |item|
+          = render 'shared/search-item' , item: item
 .second-head
   .second-head__box
     メルカリ

--- a/app/views/shared/_search-item.haml
+++ b/app/views/shared/_search-item.haml
@@ -1,0 +1,22 @@
+-# localオプションで変数をitemに渡してください
+-# 使用例です。
+-#  = render 'shared/search-item' ,item: @test
+
+-# sold-flagは売約済みか否かを示す部分です。
+-# 画像投稿機能の実装が済みましたらimagetag""内にその商品の画像を持ってくる部分を追記してください
+
+.itemsearch-box
+  - if item.buyer_id != nil
+    .sold-flag  
+    .sold-flag__text
+      sold 
+  = link_to item_path(item.id) ,class: "itemsearch-box__link" do
+    = image_tag "",class:"itemsearch-box__picture"
+    .itemsearch-box__discription
+      = item.name
+      .itemsearch-box__discription__info
+        .itemsearch-box__discription__price
+          ¥
+          = item.price
+        .itemsearch-box__discription__like
+          = fa_icon 'heart-o', class:'heart'


### PR DESCRIPTION
## What
データベースから引っ張ってきたデータを一覧表示する

## Why
検索結果を見やすくするため
開発者は簡単に部分テンプレートでアイテムを表示できます


（備考）
今回の変更では、出品機能が未実装のため画像をつけるとエラーが出ます。
よって後から追記する形としました。

部分テンプレートはこれからの変更時にエラーが出ないように、collectionオプションではなくeachで書いています。よろしくお願いします。

以下、確認画像です。

<img width="1277" alt="スクリーンショット 2019-08-11 8 59 15" src="https://user-images.githubusercontent.com/51849294/62831142-76a0c300-bc55-11e9-9fa8-137649fa277a.png">

<img width="1277" alt="スクリーンショット 2019-08-11 8 58 01" src="https://user-images.githubusercontent.com/51849294/62831141-743e6900-bc55-11e9-8902-f7e98a467d86.png">
