### PR TITLE
カテゴリ検索の改善

### DIFF
--- a/app/controllers/category_controller.rb
+++ b/app/controllers/category_controller.rb
@@ -9,8 +9,16 @@ class CategoryController < ApplicationController
 
   def show
     @category = Category.find(params[:id])
-    # @itemsはより精度の高い検索結果を実装した後に配列で返す予定です。（8.10 祖父江）
-    @items = Item.where(category_id: params[:id])
    
+    if @category.descendants.exists?
+      @items = []
+      @items += Item.where(category_id: params[:id])
+      @category.descendants.ids.each do |id|
+        @items += Item.where(category_id: id)
+      end
+    else
+      @items = Item.where(category_id: params[:id])
+    end
   end
+  
 end

--- a/app/views/category/show.haml
+++ b/app/views/category/show.haml
@@ -16,8 +16,7 @@
   .category-show__title
     = @category.name + "の商品一覧"
   .category-show__results
-    -# バグ対策のため
-    -# - @items.each do |item|
+    - @items.each do |item|
       = render 'shared/search-item' , item: item
 
 .toppage-footer__image


### PR DESCRIPTION
## What
app/views/category/show.haml 
本番環境のバグが直ったので、コメントアウトを消しました。

app/controllers/category_controller.rb
検索の処理を見直し、出品時に付与されたidに基づき、配列で検索結果が帰るようにしています。
基本的にItemのテーブルには孫カテゴリのidが入るのですが、親や子のidが万一入った場合でも検索できるようにしています。

## Why
カテゴリ検索性能の向上のため

このように検索カテゴリに対応して結果が出てきます。
https://gyazo.com/9270cfd602b3e50a1a7f0f44e57b0a30
（テストのため画像は表示していません）