### PR TITLE
型変更、正規表現、リンク繋ぎ、バリデーション

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -46,7 +46,7 @@ class SignupController < ApplicationController
     family_name_kana: session[:family_name_kana],
     first_name_kana: session[:first_name_kana],
     cellphone_number: session[:cellphone_number],
-    post_number: session[:post_number],
+    post_number: session[:post_number].gsub(/-/,''),
     prefecture: session[:prefecture],
     city: session[:city],
     address: session[:address],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,8 +16,9 @@ class User < ApplicationRecord
   validates :birthday_year, {presence: true}
   validates :birthday_month, {presence: true}
   validates :birthday, {presence: true}
-  validates :post_number, {presence: true}
+  validates :post_number, presence: true,numericality:{only_integer: true}
   validates :prefecture, {presence: true}
   validates :city, {presence: true}
   validates :address, {presence: true}
+  validates :phone_number,numericality:{only_integer: true}
 end

--- a/app/views/signup/new_login_complete.haml
+++ b/app/views/signup/new_login_complete.haml
@@ -43,7 +43,7 @@
               ありがとうございます。
             %p.complete-inner__contents__text
               会員登録が完了しました。
-            = link_to root_path, class:"" do
+            = link_to root_path do
               %button.complete-inner__submit
                 メルカリをはじめる
     = render "shared/footer-log"

--- a/app/views/signup/new_login_complete.haml
+++ b/app/views/signup/new_login_complete.haml
@@ -43,6 +43,7 @@
               ありがとうございます。
             %p.complete-inner__contents__text
               会員登録が完了しました。
-            %button.complete-inner__submit
-              メルカリをはじめる
+            = link_to root_path, class:"" do
+              %button.complete-inner__submit
+                メルカリをはじめる
     = render "shared/footer-log"

--- a/db/migrate/20190812031001_change_data_cellphone_number_to_users.rb
+++ b/db/migrate/20190812031001_change_data_cellphone_number_to_users.rb
@@ -1,0 +1,5 @@
+class ChangeDataCellphoneNumberToUsers < ActiveRecord::Migration[5.2]
+  def change
+    change_column :users, :cellphone_number, :string
+  end
+end

--- a/db/migrate/20190812031208_change_data_post_number_to_users.rb
+++ b/db/migrate/20190812031208_change_data_post_number_to_users.rb
@@ -1,0 +1,5 @@
+class ChangeDataPostNumberToUsers < ActiveRecord::Migration[5.2]
+  def change
+    change_column :users, :post_number, :string
+  end
+end

--- a/db/migrate/20190812031340_change_data_phone_number_to_users.rb
+++ b/db/migrate/20190812031340_change_data_phone_number_to_users.rb
@@ -1,0 +1,5 @@
+class ChangeDataPhoneNumberToUsers < ActiveRecord::Migration[5.2]
+  def change
+    change_column :users, :phone_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_31_031810) do
+ActiveRecord::Schema.define(version: 2019_08_12_031340) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -56,18 +56,18 @@ ActiveRecord::Schema.define(version: 2019_07_31_031810) do
     t.string "family_name_kana", null: false
     t.string "first_name_kana", null: false
     t.string "email", null: false
-    t.integer "cellphone_number", null: false
+    t.string "cellphone_number", null: false
     t.text "profile"
     t.string "image"
     t.integer "birthday_year", null: false
     t.integer "birthday_month", null: false
     t.integer "birthday", null: false
-    t.integer "post_number", null: false
+    t.string "post_number", null: false
     t.string "prefecture", null: false
     t.string "city", null: false
     t.string "address", null: false
     t.string "building_name"
-    t.integer "phone_number"
+    t.string "phone_number"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "encrypted_password", default: "", null: false


### PR DESCRIPTION
#What
ユーザーテーブルのカラムの型変更
ユーザーモデルのバリデーション
郵便番号の正規表現
新規登録後のリンク繋ぎ

#Why
電話番号の０が認識されなかったので絡む変更
郵便番号のハイフンを消す正規表現をして数字のみ保存させるため
作業効率のため
