### PR TITLE
トップページの修正

### DIFF
--- a/app/assets/stylesheets/_item-search_template.scss
+++ b/app/assets/stylesheets/_item-search_template.scss
@@ -61,3 +61,7 @@
     -webkit-transform: rotate(-45deg);
   }
 }
+
+.toppage-item-card{
+  position: relative;
+}

--- a/app/views/shared/_toppage-itembox.haml
+++ b/app/views/shared/_toppage-itembox.haml
@@ -2,16 +2,25 @@
 - @items.each do |item|
   .item-box-contents__items-box 
     = link_to item_path(item.id), class: "item-box-contents__items-box__name" do
-      .item-box-contents__items-box__photo
-        -# = image_tag "#{item.images.first.url}", class: 'toppage-item-pic'
+      .item-box-contents__items-box__photo.toppage-item-card
+        - if item.buyer_id != nil
+          .sold-flag  
+          .sold-flag__text
+            sold 
+        - begin
+          = image_tag "#{item.images.first.url}",class:"toppage-item-pic" 
+        - rescue  
+          = image_tag "",class:"itemsearch-box__picture" 
       .item-box-contents__items-box__body
         .item-box-contents__items-box__body__name
           = item.name
         .item-box-contents__items-box__body__number
           .items-box-price
-            = item.price
+            - price =  add_comma(item.price)
+            = "￥" + price
           .items-box-heart
-            .items-box-heart__icon
-              = fa_icon 'heart', class: "search-icon-right"
-            .items-box-heart__count
-              2
+          -#  いいね機能を実装する場合は以下を外してください。
+            -# .items-box-heart__icon
+            -#   = fa_icon 'heart', class: "search-icon-right"
+            -# .items-box-heart__count
+            -#   2


### PR DESCRIPTION
## What 
畠山さん作業のトップページのビューに売約済みの表示を表示するif文
料金にコンマを打つメソッド
画像表示、（万一例外があっても機能する）を追加しました。

## Why
みやすいトップページのため、エラーリスクの低減のため

確認画像は以下です。

備考："#{item.images.first.url}"は、こうしないと画像が表示されなかたっためこの形です。


<img width="1249" alt="スクリーンショット 2019-08-14 14 14 43" src="https://user-images.githubusercontent.com/51849294/62996544-046fee80-bea0-11e9-9558-f941510d5a6e.png">
